### PR TITLE
Use pyttsx watcher for local backend

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ case "$WATCHER" in
     WATCH_CMD=(python watchers/tts_watch_piper.py)
     ;;
   local|sapi|LOCAL)
-    WATCH_CMD=(python watchers/tts_watch_local.py)
+    WATCH_CMD=(python watchers/tts_watch_pyttsx.py)
     ;;
   *)
     echo "[entrypoint] Unknown BACKEND '${WATCHER}', falling back to 'edge'"


### PR DESCRIPTION
## Summary
- Point local backend to `watchers/tts_watch_pyttsx.py`
- Confirmed watcher selection for edge, piper, local, and fallback backends

## Testing
- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh`
- `pytest`
- `PYTHONUNBUFFERED=1 BACKEND=edge timeout 5 bash ../entrypoint.sh`
- `PYTHONUNBUFFERED=1 BACKEND=piper timeout 5 bash ../entrypoint.sh`
- `PYTHONUNBUFFERED=1 BACKEND=local timeout 5 bash ../entrypoint.sh`
- `PYTHONUNBUFFERED=1 BACKEND=foobar timeout 5 bash ../entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68af67356d24832488ed1c960560c49e