### PR TITLE
Organize output MP3s into titled folders

### DIFF
--- a/app/watchers/tts_watch_pyttsx.py
+++ b/app/watchers/tts_watch_pyttsx.py
@@ -18,6 +18,7 @@ import time
 import subprocess
 from pathlib import Path
 from typing import Optional
+import json
 
 import pyttsx3
 
@@ -97,9 +98,24 @@ def synth_to_wav(text_path: Path, wav_path: Path):
     engine.save_to_file(text, str(wav_path))
     engine.runAndWait()
 
+def out_path(base: str) -> Path:
+    meta = IN_DIR / f"{base}.json"
+    out_mp3 = OUT_DIR / f"{base}.mp3"
+    if meta.exists():
+        try:
+            data = json.loads(meta.read_text(encoding="utf-8"))
+            rel = data.get("output_rel")
+            if rel:
+                out_mp3 = OUT_DIR / rel
+        except Exception:
+            pass
+    out_mp3.parent.mkdir(parents=True, exist_ok=True)
+    return out_mp3
+
+
 def process_job(txt_path: Path):
     base = txt_path.stem  # e.g. example.com-a1b2c3d4e5f6a7b8
-    out_mp3 = OUT_DIR / f"{base}.mp3"
+    out_mp3 = out_path(base)
     if out_mp3.exists() and out_mp3.stat().st_size > 0:
         return  # already done
 
@@ -154,7 +170,7 @@ def main():
     while True:
         for txt in IN_DIR.glob("*.txt"):
             base = txt.stem
-            out_mp3 = OUT_DIR / f"{base}.mp3"
+            out_mp3 = out_path(base)
             if base in seen or (out_mp3.exists() and out_mp3.stat().st_size > 0):
                 continue
             seen.add(base)

--- a/app/watchers/tts_watch_stub.py
+++ b/app/watchers/tts_watch_stub.py
@@ -2,6 +2,7 @@
 import time
 from pathlib import Path
 import shutil
+import json
 
 IN_DIR = Path(__file__).resolve().parents[1] / "jobs" / "incoming"
 OUT_DIR = Path(__file__).resolve().parents[1] / "jobs" / "outgoing"
@@ -23,13 +24,28 @@ def main():
     seen = set()
 
     print(f"Watching {IN_DIR} → {OUT_DIR}")
+
+    def out_path(base: str) -> Path:
+        meta = IN_DIR / f"{base}.json"
+        out = OUT_DIR / f"{base}.mp3"
+        if meta.exists():
+            try:
+                data = json.loads(meta.read_text(encoding="utf-8"))
+                rel = data.get("output_rel")
+                if rel:
+                    out = OUT_DIR / rel
+            except Exception:
+                pass
+        out.parent.mkdir(parents=True, exist_ok=True)
+        return out
+
     while True:
         for txt in IN_DIR.glob("*.txt"):
             base = txt.stem  # e.g. example.com-abcdef1234567890
             if base in seen:
                 continue
             seen.add(base)
-            out = OUT_DIR / f"{base}.mp3"
+            out = out_path(base)
 
             # If an mp3 already exists, skip
             if out.exists():


### PR DESCRIPTION
## Summary
- Derive human-readable output paths from URLs, e.g., `My Friend Bobby/My Friend Bobby 006.mp3`
- Store desired output path in job metadata and use it when resolving MP3 and error file locations
- Update TTS watchers to honor metadata and create nested folders for outputs

## Testing
- `python -m py_compile app/app.py app/watchers/tts_watch_edge.py app/watchers/tts_watch_piper.py app/watchers/tts_watch_stub.py app/watchers/tts_watch_pyttsx.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6baa4f1c832493b3b6301490f9b6