### PR TITLE
Add metadata parsing and tagging for TTS outputs

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,4 +5,5 @@ beautifulsoup4
 pyttsx3
 edge-tts
 python-multipart
+mutagen
 

--- a/app/watchers/job_utils.py
+++ b/app/watchers/job_utils.py
@@ -1,0 +1,74 @@
+import json
+import os
+import re
+from datetime import datetime
+from email.parser import Parser
+from email.utils import parseaddr, parsedate_to_datetime
+from pathlib import Path
+
+from mutagen.easyid3 import EasyID3
+from mutagen.id3 import ID3, ID3NoHeaderError
+
+
+def extract_track_number(stem: str) -> int | None:
+    """Return trailing integer from filename stem, if present."""
+    m = re.search(r"(\d+)$", stem)
+    return int(m.group(1)) if m else None
+
+
+def parse_job_file(text_path: Path, base: str) -> tuple[dict, str]:
+    """Parse SMTP style headers and body from a job text file.
+
+    Returns metadata dict and body text (stripped).
+    """
+    raw = text_path.read_text(encoding="utf-8", errors="replace").replace("\r\n", "\n")
+    header_blob, body = ("", raw)
+    if "\n\n" in raw:
+        header_blob, body = raw.split("\n\n", 1)
+    headers = Parser().parsestr(header_blob)
+    artist = parseaddr(headers.get("From", ""))[0].strip()
+    subject = headers.get("Subject", "").strip()
+    date_str = headers.get("Date", "").strip()
+    iso_date = ""
+    if date_str:
+        try:
+            iso_date = parsedate_to_datetime(date_str).isoformat()
+        except Exception:
+            iso_date = ""
+    track = extract_track_number(base)
+    meta: dict[str, object] = {"from": artist, "subject": subject, "date": iso_date}
+    if track is not None:
+        meta["track"] = track
+    return meta, body.strip()
+
+
+def _ensure_id3(mp3_path: Path) -> None:
+    try:
+        ID3(mp3_path)
+    except ID3NoHeaderError:
+        ID3().save(mp3_path)
+
+
+def finalize_output(mp3_path: Path, meta: dict) -> None:
+    """Write JSON metadata, apply ID3 tags, and touch file mtime."""
+    json_path = mp3_path.with_suffix(".json")
+    json_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    _ensure_id3(mp3_path)
+    tags = EasyID3(mp3_path)
+    if meta.get("from"):
+        tags["artist"] = meta["from"]
+    if meta.get("subject"):
+        tags["title"] = meta["subject"]
+    if meta.get("track") is not None:
+        tags["tracknumber"] = str(meta["track"])
+    tags.save()
+
+    date_str = meta.get("date")
+    if isinstance(date_str, str) and date_str:
+        try:
+            dt = datetime.fromisoformat(date_str)
+            ts = dt.timestamp()
+            os.utime(mp3_path, (ts, ts))
+        except Exception:
+            pass

--- a/app/watchers/tts_watch_edge.py
+++ b/app/watchers/tts_watch_edge.py
@@ -5,6 +5,7 @@ import asyncio
 from pathlib import Path
 import traceback
 import edge_tts
+from job_utils import parse_job_file, finalize_output
 
 ROOT = Path(__file__).resolve().parents[1]
 IN_DIR = ROOT / "jobs" / "incoming"
@@ -99,12 +100,11 @@ def main():
                 continue
             seen.add(base)
 
-            raw = txt_path.read_text(encoding="utf-8", errors="replace")
-            txt = raw.strip()
+            meta, txt = parse_job_file(txt_path, base)
             print(f"[+] {base}: text_len={len(txt)}")
 
             if len(txt) == 0:
-                write_err(base, "Empty text after preprocessing", None, raw)
+                write_err(base, "Empty text after preprocessing", None, txt)
                 continue
 
             start = time.time()
@@ -112,6 +112,7 @@ def main():
                 bytes_written = loop.run_until_complete(synth_to_mp3(txt, out_mp3))
                 dur = time.time() - start
                 print(f"[✓] {base}: finalized {out_mp3.name} ({bytes_written} bytes) in {dur:.1f}s")
+                finalize_output(out_mp3, meta)
 
                 # Clear stale error file if present
                 if err_file.exists():

--- a/app/watchers/tts_watch_stub.py
+++ b/app/watchers/tts_watch_stub.py
@@ -2,6 +2,7 @@
 import time
 from pathlib import Path
 import shutil
+from job_utils import parse_job_file, finalize_output
 
 IN_DIR = Path(__file__).resolve().parents[1] / "jobs" / "incoming"
 OUT_DIR = Path(__file__).resolve().parents[1] / "jobs" / "outgoing"
@@ -35,8 +36,9 @@ def main():
             if out.exists():
                 continue
 
-            # ---- replace this with REAL TTS ----
+            meta, _ = parse_job_file(txt, base)
             write_stub_mp3(out)
+            finalize_output(out, meta)
             print(f"Created {out.name}")
 
         time.sleep(1.0)


### PR DESCRIPTION
## Summary
- parse SMTP-style headers from job text files
- apply ID3 tags, JSON metadata, and timestamps to generated MP3s
- add mutagen dependency for ID3 support

## Testing
- `python -m py_compile app/watchers/job_utils.py app/watchers/tts_watch_edge.py app/watchers/tts_watch_piper.py app/watchers/tts_watch_pyttsx.py app/watchers/tts_watch_stub.py`


------
https://chatgpt.com/codex/tasks/task_e_68af6e755f6c8324bcee03388c1f7c27