### PR TITLE
Refactor watchers for Linux and install Piper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY app/ /app/
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Python deps and Piper TTS binary
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir piper-tts
+
+# Location for Piper voice models; mount host folder here
+RUN mkdir -p /models
+VOLUME ["/models"]
+ENV NIFTYTTS_PIPER_MODEL=/models
 
 # Add entrypoint
 COPY entrypoint.sh /app/entrypoint.sh

--- a/app/watchers/tts_watch_piper.py
+++ b/app/watchers/tts_watch_piper.py
@@ -2,14 +2,14 @@
 """
 Piper watcher:
 - Watches jobs/incoming/*.txt
-- Calls piper.exe with a selected model to produce WAV
+- Calls piper with a selected model to produce WAV
 - Encodes WAV → MP3 using ffmpeg
 - Atomic move into jobs/outgoing/<base>.mp3
 
 Env vars (or edit defaults below):
-  NIFTYTTS_PIPER_EXE   : path to piper.exe
-  NIFTYTTS_PIPER_MODEL : path to voice model .onnx
-  NIFTYTTS_FFMPEG_PATH : path to ffmpeg.exe
+  NIFTYTTS_PIPER_EXE   : path to piper executable (default ``piper`` in PATH)
+  NIFTYTTS_PIPER_MODEL : path to voice model .onnx or directory containing models (default ``/models``)
+  NIFTYTTS_FFMPEG_PATH : path to ffmpeg (default ``ffmpeg`` in PATH)
   NIFTYTTS_PIPER_LENGTH: speaking rate (e.g., 1.0 normal, 0.9 slower, 1.1 faster)
   NIFTYTTS_PIPER_NOISE : noise scale (0.667 default)
 """
@@ -17,6 +17,7 @@ Env vars (or edit defaults below):
 import os
 import time
 import subprocess
+import traceback
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -24,19 +25,34 @@ IN_DIR = ROOT / "jobs" / "incoming"
 OUT_DIR = ROOT / "jobs" / "outgoing"
 TMP_DIR = ROOT / "jobs" / "tmp"
 
-PIPER_EXE   = os.environ.get("NIFTYTTS_PIPER_EXE",   r"C:\Users\Duane\Downloads\piper\piper.exe")
-PIPER_MODEL = os.environ.get("NIFTYTTS_PIPER_MODEL", r"C:\Users\Duane\Downloads\piper\models\en_US-joe-medium.onnx")
-FFMPEG_PATH = os.environ.get("NIFTYTTS_FFMPEG_PATH", r"C:\Users\Duane\Downloads\ffmpeg\ffmpeg.exe")
+PIPER_EXE   = os.environ.get("NIFTYTTS_PIPER_EXE",   "piper")
+PIPER_MODEL = os.environ.get("NIFTYTTS_PIPER_MODEL", "/models")
+FFMPEG_PATH = os.environ.get("NIFTYTTS_FFMPEG_PATH", "ffmpeg")
+
+# Resolve model directory to first .onnx if needed
+_model_path = Path(PIPER_MODEL)
+if _model_path.is_dir():
+    first = next(_model_path.glob("*.onnx"), None)
+    if first:
+        PIPER_MODEL = str(first)
 
 PIPER_LENGTH = os.environ.get("NIFTYTTS_PIPER_LENGTH", "1.0")
 PIPER_NOISE  = os.environ.get("NIFTYTTS_PIPER_NOISE",  "0.667")
 
-POLL_INTERVAL = 0.5
+POLL_INTERVAL = float(os.environ.get("NIFTYTTS_POLL_INTERVAL", "0.5"))
+SYNTH_TIMEOUT = int(os.environ.get("NIFTYTTS_SYNTH_TIMEOUT", "600"))
+MIN_MP3_BYTES = int(os.environ.get("NIFTYTTS_MIN_MP3_BYTES", "1024"))
 
 def ensure_dirs():
     IN_DIR.mkdir(parents=True, exist_ok=True)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     TMP_DIR.mkdir(parents=True, exist_ok=True)
+    # Clean any stale tmp files
+    for p in TMP_DIR.glob("*.tmp"):
+        try:
+            p.unlink()
+        except Exception:
+            pass
 
 def check_tool(path: str, args: list[str]) -> bool:
     """Return True only if the tool runs successfully.
@@ -48,14 +64,24 @@ def check_tool(path: str, args: list[str]) -> bool:
     detected early."""
 
     try:
-        proc = subprocess.run([path, *args], capture_output=True, check=False)
+        proc = subprocess.run([path, *args], capture_output=True, check=False, timeout=15)
         return proc.returncode == 0
     except FileNotFoundError:
         return False
 
-def piper_to_wav(text_path: Path, wav_path: Path):
-    text = text_path.read_text(encoding="utf-8", errors="replace")
-    # Pipe text to Piper's stdin
+
+def write_err(base: str, msg: str, exc: BaseException | None = None, text_sample: str = ""):
+    err = OUT_DIR / f"{base}.err.txt"
+    blob = [f"ERROR: {msg}"]
+    if exc:
+        blob.append("\nTRACEBACK:\n" + "".join(traceback.format_exception(exc)))
+    if text_sample:
+        blob.append("\nTEXT SAMPLE (first 400 chars):\n" + text_sample[:400])
+    err.write_text("\n\n".join(blob), encoding="utf-8")
+    print(f"[x] {base}: {msg}. Details -> {err.name}")
+
+
+def piper_to_wav(text: str, wav_path: Path):
     cmd = [
         PIPER_EXE,
         "--model", PIPER_MODEL,
@@ -63,8 +89,7 @@ def piper_to_wav(text_path: Path, wav_path: Path):
         "--noise_scale", PIPER_NOISE,
         "--output_file", str(wav_path),
     ]
-    proc = subprocess.run(cmd, input=text.encode("utf-8"), check=True)
-    return proc.returncode == 0
+    subprocess.run(cmd, input=text.encode("utf-8"), check=True, timeout=SYNTH_TIMEOUT)
 
 def wav_to_mp3(wav_path: Path, mp3_tmp: Path):
     cmd = [
@@ -74,16 +99,23 @@ def wav_to_mp3(wav_path: Path, mp3_tmp: Path):
         "-vn", "-ac", "1", "-ar", "44100", "-b:a", "80k",
         str(mp3_tmp),
     ]
-    subprocess.run(cmd, check=True)
+    subprocess.run(cmd, check=True, timeout=SYNTH_TIMEOUT)
 
 def process_job(txt: Path):
     base = txt.stem
     out_mp3 = OUT_DIR / f"{base}.mp3"
-    if out_mp3.exists() and out_mp3.stat().st_size > 0:
+    err_file = OUT_DIR / f"{base}.err.txt"
+    if out_mp3.exists() and out_mp3.stat().st_size > 0 or (err_file.exists() and err_file.stat().st_size > 0):
         return
 
     tmp_wav = TMP_DIR / f"{base}.wav"
     tmp_mp3 = TMP_DIR / f"{base}.mp3"
+
+    raw = txt.read_text(encoding="utf-8", errors="replace")
+    text = raw.strip()
+    if len(text) == 0:
+        write_err(base, "Empty text after preprocessing", None, raw)
+        return
 
     try:
         print(f"[+] Piper synth: {txt.name}")
@@ -91,11 +123,25 @@ def process_job(txt: Path):
             raise RuntimeError(f"Piper not found or failed to run: {PIPER_EXE}")
         if not check_tool(FFMPEG_PATH, ["-version"]):
             raise RuntimeError(f"ffmpeg not found or failed to run: {FFMPEG_PATH}")
+        if not Path(PIPER_MODEL).is_file():
+            raise FileNotFoundError(f"Piper model not found: {PIPER_MODEL}")
 
-        piper_to_wav(txt, tmp_wav)
+        piper_to_wav(text, tmp_wav)
         wav_to_mp3(tmp_wav, tmp_mp3)
+        size = tmp_mp3.stat().st_size
+        if size < MIN_MP3_BYTES:
+            raise RuntimeError(f"Generated MP3 too small ({size} bytes)")
         tmp_mp3.replace(out_mp3)
         print(f"[✓] wrote {out_mp3.name}")
+
+        if err_file.exists():
+            try:
+                err_file.unlink()
+                print(f"[-] {base}: cleared stale error log")
+            except Exception:
+                pass
+    except Exception as e:
+        write_err(base, "Exception during synthesis", e, text)
     finally:
         for p in (tmp_wav, tmp_mp3):
             try:
@@ -113,13 +159,11 @@ def main():
         for txt in IN_DIR.glob("*.txt"):
             base = txt.stem
             out_mp3 = OUT_DIR / f"{base}.mp3"
-            if base in seen or (out_mp3.exists() and out_mp3.stat().st_size > 0):
+            err_file = OUT_DIR / f"{base}.err.txt"
+            if base in seen or (out_mp3.exists() and out_mp3.stat().st_size > 0) or (err_file.exists() and err_file.stat().st_size > 0):
                 continue
             seen.add(base)
-            try:
-                process_job(txt)
-            except Exception as e:
-                print(f"[x] {base}: {e}")
+            process_job(txt)
         time.sleep(POLL_INTERVAL)
 
 if __name__ == "__main__":

--- a/app/watchers/tts_watch_pyttsx.py
+++ b/app/watchers/tts_watch_pyttsx.py
@@ -2,20 +2,21 @@
 """
 Local TTS watcher for NiftyTTS:
 - Watches jobs/incoming/*.txt
-- Uses pyttsx3 (Windows SAPI) to synthesize a WAV
+- Uses pyttsx3 to synthesize a WAV
 - Converts WAV -> MP3 via ffmpeg
 - Atomically writes jobs/outgoing/<base>.mp3
 - Skips jobs already processed
 
 Config via environment variables (optional):
-  NIFTYTTS_VOICE_SUBSTR   : case-insensitive substring to choose a voice
-  NIFTYTTS_RATE_WPM       : integer words-per-minute (default 180)
-  NIFTYTTS_VOLUME         : 0.0..1.0 (default 1.0)
+  NIFTYTTS_VOICE_SUBSTR : case-insensitive substring to choose a voice
+  NIFTYTTS_RATE_WPM     : integer words-per-minute (default 180)
+  NIFTYTTS_VOLUME       : 0.0..1.0 (default 1.0)
 """
 
 import os
 import time
 import subprocess
+import traceback
 from pathlib import Path
 from typing import Optional
 
@@ -30,42 +31,54 @@ VOICE_SUBSTR = os.environ.get("NIFTYTTS_VOICE_SUBSTR", "").strip()
 RATE_WPM = int(os.environ.get("NIFTYTTS_RATE_WPM", "180"))
 VOLUME = float(os.environ.get("NIFTYTTS_VOLUME", "1.0"))
 
-POLL_INTERVAL = 0.5   # seconds
+POLL_INTERVAL = float(os.environ.get("NIFTYTTS_POLL_INTERVAL", "0.5"))
 SILENT_SECONDS_AFTER_DONE = 1.0
+SYNTH_TIMEOUT = int(os.environ.get("NIFTYTTS_SYNTH_TIMEOUT", "600"))
+MIN_MP3_BYTES = int(os.environ.get("NIFTYTTS_MIN_MP3_BYTES", "1024"))
 
-FFMPEG_PATH = os.environ.get(
-    "NIFTYTTS_FFMPEG_PATH",
-    r"C:\Users\Duane\Downloads\ffmpeg\ffmpeg.exe"
-)
-
+FFMPEG_PATH = os.environ.get("NIFTYTTS_FFMPEG_PATH", "ffmpeg")
 
 
 def ensure_dirs():
     IN_DIR.mkdir(parents=True, exist_ok=True)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     TMP_DIR.mkdir(parents=True, exist_ok=True)
+    for p in TMP_DIR.glob("*.tmp"):
+        try:
+            p.unlink()
+        except Exception:
+            pass
+
 
 def ffmpeg_exists() -> bool:
     try:
-        subprocess.run([FFMPEG_PATH, "-version"], capture_output=True, check=False)
-        return True
+        proc = subprocess.run(
+            [FFMPEG_PATH, "-version"], capture_output=True, check=False, timeout=15
+        )
+        return proc.returncode == 0
     except FileNotFoundError:
         return False
 
+
 def wav_to_mp3(wav_path: Path, mp3_tmp: Path):
-    # 64 kbps, mono, 44.1kHz — tweak to taste
     cmd = [
-        FFMPEG_PATH, "-y",
-        "-hide_banner", "-loglevel", "error",
-        "-i", str(wav_path),
+        FFMPEG_PATH,
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        str(wav_path),
         "-vn",
-        "-ac", "1",
-        "-ar", "44100",
-        "-b:a", "64k",
+        "-ac",
+        "1",
+        "-ar",
+        "44100",
+        "-b:a",
+        "64k",
         str(mp3_tmp),
     ]
-    subprocess.run(cmd, check=True)
-
+    subprocess.run(cmd, check=True, timeout=SYNTH_TIMEOUT)
 
 
 def pick_voice(engine: pyttsx3.Engine, substr: str) -> Optional[str]:
@@ -75,57 +88,76 @@ def pick_voice(engine: pyttsx3.Engine, substr: str) -> Optional[str]:
     s = substr.lower()
     chosen = None
     for v in engine.getProperty("voices"):
-        # On Windows SAPI, 'name' contains a friendly string like "Microsoft David Desktop - English (United States)"
         name = getattr(v, "name", "") or ""
         if s in name.lower():
             chosen = v.id
             break
     return chosen
 
-def synth_to_wav(text_path: Path, wav_path: Path):
-    engine = pyttsx3.init()  # SAPI5 on Windows
-    # Voice selection
+
+def synth_to_wav(text: str, wav_path: Path):
+    engine = pyttsx3.init()
     vid = pick_voice(engine, VOICE_SUBSTR)
     if vid:
         engine.setProperty("voice", vid)
-    # Speed & volume
     engine.setProperty("rate", RATE_WPM)
     engine.setProperty("volume", VOLUME)
-    # Load text
-    text = text_path.read_text(encoding="utf-8", errors="replace")
-    # Save to WAV (blocking until done)
     engine.save_to_file(text, str(wav_path))
     engine.runAndWait()
 
-def process_job(txt_path: Path):
-    base = txt_path.stem  # e.g. example.com-a1b2c3d4e5f6a7b8
-    out_mp3 = OUT_DIR / f"{base}.mp3"
-    if out_mp3.exists() and out_mp3.stat().st_size > 0:
-        return  # already done
 
-    # Temporary files in tmp/
+def write_err(base: str, msg: str, exc: BaseException | None = None, text_sample: str = ""):
+    err = OUT_DIR / f"{base}.err.txt"
+    blob = [f"ERROR: {msg}"]
+    if exc:
+        blob.append("\nTRACEBACK:\n" + "".join(traceback.format_exception(exc)))
+    if text_sample:
+        blob.append("\nTEXT SAMPLE (first 400 chars):\n" + text_sample[:400])
+    err.write_text("\n\n".join(blob), encoding="utf-8")
+    print(f"[x] {base}: {msg}. Details -> {err.name}")
+
+
+def process_job(txt_path: Path):
+    base = txt_path.stem
+    out_mp3 = OUT_DIR / f"{base}.mp3"
+    err_file = OUT_DIR / f"{base}.err.txt"
+    if out_mp3.exists() and out_mp3.stat().st_size > 0 or (err_file.exists() and err_file.stat().st_size > 0):
+        return
+
     wav_tmp = TMP_DIR / f"{base}.wav"
     mp3_tmp = TMP_DIR / f"{base}.mp3"
 
+    raw = txt_path.read_text(encoding="utf-8", errors="replace")
+    text = raw.strip()
+    if len(text) == 0:
+        write_err(base, "Empty text after preprocessing", None, raw)
+        return
+
     try:
         print(f"[+] Synthesizing: {txt_path.name}")
-        synth_to_wav(txt_path, wav_tmp)
+        synth_to_wav(text, wav_tmp)
 
         if not ffmpeg_exists():
-            print("[!] ffmpeg not found; install it or add to PATH.")
-            print(f"    Leaving WAV at: {wav_tmp}")
-            return
+            raise RuntimeError(f"ffmpeg not found or failed to run: {FFMPEG_PATH}")
 
         wav_to_mp3(wav_tmp, mp3_tmp)
+        size = mp3_tmp.stat().st_size
+        if size < MIN_MP3_BYTES:
+            raise RuntimeError(f"Generated MP3 too small ({size} bytes)")
 
-        # Atomic move: tmp -> outgoing
         mp3_tmp.replace(out_mp3)
         print(f"[✓] Wrote: {out_mp3.name}")
 
+        if err_file.exists():
+            try:
+                err_file.unlink()
+                print(f"[-] {base}: cleared stale error log")
+            except Exception:
+                pass
+
     except Exception as e:
-        print(f"[x] Error processing {txt_path.name}: {e}")
+        write_err(base, "Exception during synthesis", e, text)
     finally:
-        # Clean temp WAV/MP3 if present
         for p in (wav_tmp, mp3_tmp):
             try:
                 if p.exists():
@@ -133,12 +165,14 @@ def process_job(txt_path: Path):
             except Exception:
                 pass
 
+
 def list_voices():
     engine = pyttsx3.init()
     voices = engine.getProperty("voices")
     print("Available voices (use NIFTYTTS_VOICE_SUBSTR to select by substring):")
     for v in voices:
         print("-", getattr(v, "name", v.id))
+
 
 def main():
     ensure_dirs()
@@ -148,18 +182,20 @@ def main():
         list_voices()
 
     seen = set()
-    # tiny delay if the web app just wrote a fresh file and is about to check
     time.sleep(SILENT_SECONDS_AFTER_DONE)
 
     while True:
         for txt in IN_DIR.glob("*.txt"):
             base = txt.stem
             out_mp3 = OUT_DIR / f"{base}.mp3"
-            if base in seen or (out_mp3.exists() and out_mp3.stat().st_size > 0):
+            err_file = OUT_DIR / f"{base}.err.txt"
+            if base in seen or (out_mp3.exists() and out_mp3.stat().st_size > 0) or (err_file.exists() and err_file.stat().st_size > 0):
                 continue
             seen.add(base)
             process_job(txt)
         time.sleep(POLL_INTERVAL)
 
+
 if __name__ == "__main__":
     main()
+

--- a/app/watchers/tts_watch_stub.py
+++ b/app/watchers/tts_watch_stub.py
@@ -1,10 +1,13 @@
-# watchers/tts_watch.py
+# watchers/tts_watch_stub.py
+import os
 import time
+import traceback
 from pathlib import Path
-import shutil
 
 IN_DIR = Path(__file__).resolve().parents[1] / "jobs" / "incoming"
 OUT_DIR = Path(__file__).resolve().parents[1] / "jobs" / "outgoing"
+
+POLL_INTERVAL = float(os.environ.get("NIFTYTTS_POLL_INTERVAL", "0.5"))
 
 def write_stub_mp3(target: Path):
     # Tiny silent MP3 (1 second of silence at 11025 Hz, CBR 32kbps) – good enough for testing.
@@ -16,6 +19,18 @@ def write_stub_mp3(target: Path):
         "00000000"
     )
     target.write_bytes(data)
+    
+
+def write_err(base: str, msg: str, exc: BaseException | None = None, text_sample: str = ""):
+    err = OUT_DIR / f"{base}.err.txt"
+    blob = [f"ERROR: {msg}"]
+    if exc:
+        blob.append("\nTRACEBACK:\n" + "".join(traceback.format_exception(exc)))
+    if text_sample:
+        blob.append("\nTEXT SAMPLE (first 400 chars):\n" + text_sample[:400])
+    err.write_text("\n\n".join(blob), encoding="utf-8")
+    print(f"[x] {base}: {msg}. Details -> {err.name}")
+
 
 def main():
     IN_DIR.mkdir(parents=True, exist_ok=True)
@@ -25,21 +40,33 @@ def main():
     print(f"Watching {IN_DIR} → {OUT_DIR}")
     while True:
         for txt in IN_DIR.glob("*.txt"):
-            base = txt.stem  # e.g. example.com-abcdef1234567890
-            if base in seen:
+            base = txt.stem
+            out = OUT_DIR / f"{base}.mp3"
+            err_file = OUT_DIR / f"{base}.err.txt"
+            if base in seen or (out.exists() and out.stat().st_size > 0) or (err_file.exists() and err_file.stat().st_size > 0):
                 continue
             seen.add(base)
-            out = OUT_DIR / f"{base}.mp3"
 
-            # If an mp3 already exists, skip
-            if out.exists():
+            raw = txt.read_text(encoding="utf-8", errors="replace")
+            text = raw.strip()
+            if len(text) == 0:
+                write_err(base, "Empty text after preprocessing", None, raw)
                 continue
 
-            # ---- replace this with REAL TTS ----
-            write_stub_mp3(out)
-            print(f"Created {out.name}")
+            try:
+                write_stub_mp3(out)
+                print(f"Created {out.name}")
+                if err_file.exists():
+                    try:
+                        err_file.unlink()
+                        print(f"[-] {base}: cleared stale error log")
+                    except Exception:
+                        pass
+            except Exception as e:
+                write_err(base, "Failed to write stub MP3", e, text)
 
-        time.sleep(1.0)
+        time.sleep(POLL_INTERVAL)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Refactor Piper watcher for Linux: configurable paths, timeout and error logs
- Port pyttsx and stub watchers to match app.py expectations and log errors to `.err.txt`
- Install `piper-tts` in the Docker image so `piper` is available at runtime
- Default Piper model directory to `/models` and expose it as a volume

## Testing
- `python -m py_compile app/app.py app/watchers/tts_watch_edge.py app/watchers/tts_watch_piper.py app/watchers/tts_watch_pyttsx.py app/watchers/tts_watch_stub.py`


------
https://chatgpt.com/codex/tasks/task_e_68af6d185d5c8324800de61a975f0cd1