### PR TITLE
Ensure MP3 ID3 tags use v2.3 with ID3v1 fallback

### DIFF
--- a/app/watchers/job_utils.py
+++ b/app/watchers/job_utils.py
@@ -62,7 +62,8 @@ def finalize_output(mp3_path: Path, meta: dict) -> None:
         tags["title"] = meta["subject"]
     if meta.get("track") is not None:
         tags["tracknumber"] = str(meta["track"])
-    tags.save()
+    # Write a v2.3 tag and include a v1 tag for broader player compatibility
+    tags.save(v1=2, v2_version=3)
 
     date_str = meta.get("date")
     if isinstance(date_str, str) and date_str:


### PR DESCRIPTION
## Summary
- Save ID3 tags in a more compatible format (ID3v2.3 plus ID3v1) so metadata appears in more players

## Testing
- `python -m py_compile app/watchers/job_utils.py`
- `python - <<'PY'
import subprocess, py_compile
files = subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()
for f in files:
    py_compile.compile(f)
print('all py files compiled')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af785ec77083249bbd37f5ddb9503f