### PR TITLE
Add UID/GID env vars and chown outputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Location for Piper voice models; mount host folder here
 RUN mkdir -p /models
 VOLUME ["/models"]
-ENV NIFTYTTS_PIPER_MODEL=/models
+ENV NIFTYTTS_PIPER_MODEL=/models \
+    NIFTYTTS_UID=99 \
+    NIFTYTTS_GID=100
 
 # Add entrypoint
 COPY entrypoint.sh /app/entrypoint.sh

--- a/app/README.md
+++ b/app/README.md
@@ -1,2 +1,10 @@
 # NiftyTTS
 Text to speech for Nifty stories.
+
+## Environment Variables
+
+* `NIFTYTTS_UID` – user ID that should own generated files (default `99`)
+* `NIFTYTTS_GID` – group ID that should own generated files (default `100`)
+
+Set these to your host user's UID/GID when running the container; the entrypoint
+will `chown` everything under `jobs/` to that user and group when it exits.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# IDs used to chown generated files back to the host user
+OUT_UID="${NIFTYTTS_UID:-99}"
+OUT_GID="${NIFTYTTS_GID:-100}"
+
 # Which watcher to run? default = edge
 WATCHER="${BACKEND:-edge}"
 
@@ -36,4 +40,11 @@ wait -n "$WEB_PID" "$WATCH_PID"
 EXIT_CODE=$?
 kill "$WEB_PID" "$WATCH_PID" 2>/dev/null || true
 wait || true
+
+# Chown output files to requested user/group
+if [ -d jobs ]; then
+  echo "[entrypoint] Chowning outputs to ${OUT_UID}:${OUT_GID}"
+  chown -R "${OUT_UID}:${OUT_GID}" jobs || true
+fi
+
 exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary
- add NIFTYTTS_UID and NIFTYTTS_GID environment variables
- chown generated files to the provided user/group when the container exits
- default to UID 99 and GID 100 if none specified
- document new environment variables

## Testing
- `bash -n entrypoint.sh`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af79d270108324b9b1c9079f6cb139