### PR TITLE
Ensure watcher logs are flushed and recover from malformed ID3 tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN mkdir -p /models
 VOLUME ["/models"]
 ENV NIFTYTTS_PIPER_MODEL=/models \
     NIFTYTTS_UID=99 \
-    NIFTYTTS_GID=100
+    NIFTYTTS_GID=100 \
+    PYTHONUNBUFFERED=1
 
 # Add entrypoint
 COPY entrypoint.sh /app/entrypoint.sh

--- a/app/watchers/job_utils.py
+++ b/app/watchers/job_utils.py
@@ -47,6 +47,12 @@ def _ensure_id3(mp3_path: Path) -> None:
         ID3(mp3_path)
     except ID3NoHeaderError:
         ID3().save(mp3_path)
+    except Exception:
+        try:
+            ID3().delete(mp3_path)
+        except Exception:
+            pass
+        ID3().save(mp3_path)
 
 
 def finalize_output(mp3_path: Path, meta: dict) -> None:


### PR DESCRIPTION
## Summary
- Reset ID3 tags before applying metadata so Edge-generated MP3s always receive ID3 info
- Enable unbuffered Python output in the Docker image so watcher logs appear immediately

## Testing
- `python -m py_compile watchers/job_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68af8269d9c4832496cae6ffa20ca3ed