### PR TITLE
Preserve email-style headers in job metadata

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,10 @@ Generated MP3 files and JSON metadata are written to
 `app/jobs/outgoing`.  Errors are reported in corresponding `.err.txt`
 files.  Temporary job input lives in `app/jobs/incoming`.
 
+For text submissions containing RFC822-style headers, the app extracts the
+`From`, `Subject`, and `Date` values and records them in each job's JSON
+metadata and ID3 tags.
+
 ## License
 
 See `app/LICENSE` for licensing information.


### PR DESCRIPTION
## Summary
- Parse and strip RFC822-style From, Subject, and Date headers from text submissions
- Carry extracted metadata through the form workflow and submit endpoint
- Reinsert header block into saved job text and record parsed values in job JSON

## Testing
- `python3 -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b06fa103a08324af6a99271be2a588